### PR TITLE
Added a way to indicate that an account self-destructed to traces

### DIFF
--- a/protocol_decoder/src/processed_block_trace.rs
+++ b/protocol_decoder/src/processed_block_trace.rs
@@ -268,6 +268,13 @@ impl TxnInfo {
                     }
                 }
             }
+
+            if trace
+                .self_destructed
+                .map_or(false, |self_destructed| self_destructed)
+            {
+                nodes_used_by_txn.self_destructed_accounts.push(hashed_addr);
+            }
         }
 
         let accounts_with_storage_accesses: HashSet<_> = HashSet::from_iter(
@@ -339,6 +346,7 @@ pub(crate) struct NodesUsedByTxn {
     pub(crate) storage_writes: Vec<(Nibbles, Vec<(HashedStorageAddrNibbles, Vec<u8>)>)>,
     pub(crate) state_accounts_with_no_accesses_but_storage_tries:
         HashMap<HashedAccountAddr, TrieRootHash>,
+    pub(crate) self_destructed_accounts: Vec<HashedAccountAddr>,
 }
 
 #[derive(Debug)]

--- a/protocol_decoder/src/trace_protocol.rs
+++ b/protocol_decoder/src/trace_protocol.rs
@@ -175,6 +175,11 @@ pub struct TxnTrace {
     /// Contract code that this address accessed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub code_usage: Option<ContractCodeUsage>,
+
+    /// True if the account existed before this txn but self-destructed at the
+    /// end of this txn.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub self_destructed: Option<bool>,
 }
 
 /// Contract code access type. Used by txn traces.


### PR DESCRIPTION
I think the issue with the state trie mismatch with block `10` is a self-destruct also occurs in a previous block and we need to be able to remove state in this case. This PR adds a new field to the protocol to indicate that an account that existed before the current txn was destroyed in the current txn.

As far as I know, there is no special rule like there is with storage slots where if we write `0`, then we remove the storage trie node. If this also exists for state tries, then that is probably the better route to go in this case.