### PR TITLE
Bump plonky2 and replace genesis for checkpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,5 @@ resolver = "2"
 [workspace.dependencies]
 ethereum-types = "0.14.1"
 log = "0.4.20"
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "71dff6e9827f501bc59416dc25ce06c4aec030ab" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "f8f6b07a3905185af302d58fb6b97c55d12e57be" }
 serde = "1.0.166"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,5 @@ resolver = "2"
 [workspace.dependencies]
 ethereum-types = "0.14.1"
 log = "0.4.20"
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "7efd147e0888c5c6754a4d7ee2691a2ff5c82072" }
+plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "71dff6e9827f501bc59416dc25ce06c4aec030ab" }
 serde = "1.0.166"

--- a/plonky_block_proof_gen/Cargo.toml
+++ b/plonky_block_proof_gen/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 ethereum-types = { workspace = true }
 log = { workspace = true }
 paste = "1.0.14"
-plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "71dff6e9827f501bc59416dc25ce06c4aec030ab" }
+plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "f8f6b07a3905185af302d58fb6b97c55d12e57be" }
 plonky2_evm = { workspace = true }
 protocol_decoder = { path = "../protocol_decoder" }
 serde = { workspace = true }

--- a/plonky_block_proof_gen/Cargo.toml
+++ b/plonky_block_proof_gen/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 ethereum-types = { workspace = true }
 log = { workspace = true }
 paste = "1.0.14"
-plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "7efd147e0888c5c6754a4d7ee2691a2ff5c82072" }
+plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "71dff6e9827f501bc59416dc25ce06c4aec030ab" }
 plonky2_evm = { workspace = true }
 protocol_decoder = { path = "../protocol_decoder" }
 serde = { workspace = true }

--- a/plonky_block_proof_gen/src/proof_gen.rs
+++ b/plonky_block_proof_gen/src/proof_gen.rs
@@ -1,7 +1,7 @@
 //! This module defines the proof generation methods corresponding to the three
 //! types of proofs the zkEVM internally handles.
 
-use std::sync::atomic::AtomicBool;
+use std::sync::{atomic::AtomicBool, Arc};
 
 use plonky2::util::timing::TimingTree;
 use plonky2_evm::{all_stark::AllStark, config::StarkConfig};

--- a/plonky_block_proof_gen/src/proof_gen.rs
+++ b/plonky_block_proof_gen/src/proof_gen.rs
@@ -1,6 +1,8 @@
 //! This module defines the proof generation methods corresponding to the three
 //! types of proofs the zkEVM internally handles.
 
+use std::sync::atomic::AtomicBool;
+
 use plonky2::util::timing::TimingTree;
 use plonky2_evm::{all_stark::AllStark, config::StarkConfig};
 use protocol_decoder::types::TxnProofGenIR;
@@ -37,6 +39,7 @@ impl From<String> for ProofGenError {
 pub fn generate_txn_proof(
     p_state: &ProverState,
     start_info: TxnProofGenIR,
+    abort_signal: Option<Arc<AtomicBool>>,
 ) -> ProofGenResult<GeneratedTxnProof> {
     let (intern, p_vals) = p_state
         .state
@@ -45,6 +48,7 @@ pub fn generate_txn_proof(
             &StarkConfig::standard_fast_config(),
             start_info.gen_inputs,
             &mut TimingTree::default(),
+            abort_signal,
         )
         .map_err(|err| err.to_string())?;
 

--- a/protocol_decoder/src/decoding.rs
+++ b/protocol_decoder/src/decoding.rs
@@ -132,7 +132,7 @@ impl ProcessedBlockTrace {
                                               * it here... */
                     tries,
                     trie_roots_after,
-                    genesis_state_trie_root: other_data.genesis_state_trie_root,
+                    checkpoint_state_trie_root: other_data.checkpoint_state_trie_root,
                     contract_code: txn_info.contract_code_accessed,
                     block_metadata: other_data.b_data.b_meta.clone(),
                     block_hashes: other_data.b_data.b_hashes.clone(),
@@ -350,7 +350,7 @@ fn create_dummy_gen_input(
         signed_txn: None,
         tries,
         trie_roots_after,
-        genesis_state_trie_root: other_data.genesis_state_trie_root,
+        checkpoint_state_trie_root: other_data.checkpoint_state_trie_root,
         block_metadata: other_data.b_data.b_meta.clone(),
         block_hashes: other_data.b_data.b_hashes.clone(),
         ..GenerationInputs::default()

--- a/protocol_decoder/src/proof_gen_types.rs
+++ b/protocol_decoder/src/proof_gen_types.rs
@@ -26,12 +26,12 @@ impl<T: Borrow<ExtraBlockData>> From<T> for ProofBeforeAndAfterDeltas {
 impl ProofBeforeAndAfterDeltas {
     pub fn into_extra_block_data(
         self,
-        genesis_state_trie_root: TrieRootHash,
+        checkpoint_state_trie_root: TrieRootHash,
         txn_start: TxnIdx,
         txn_end: TxnIdx,
     ) -> ExtraBlockData {
         ExtraBlockData {
-            genesis_state_trie_root,
+            checkpoint_state_trie_root,
             txn_number_before: txn_start.into(),
             txn_number_after: txn_end.into(),
             gas_used_before: self.gas_used_before,

--- a/protocol_decoder/src/types.rs
+++ b/protocol_decoder/src/types.rs
@@ -57,7 +57,7 @@ pub struct TxnProofGenIR {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct OtherBlockData {
     pub b_data: BlockLevelData,
-    pub genesis_state_trie_root: TrieRootHash,
+    pub checkpoint_state_trie_root: TrieRootHash,
 }
 
 /// Data that is specific to a block and is constant for all txns in a given


### PR DESCRIPTION
Bumps plonky2 version and replaces `genesis` state root with `checkpoint` state root.
The actual logic of targeting a given `checkpoint` is still to be done within `zero-bin`.