### PR TITLE
Add a `VerifierState`

### DIFF
--- a/plonky_block_proof_gen/src/constants.rs
+++ b/plonky_block_proof_gen/src/constants.rs
@@ -1,5 +1,7 @@
 //! Hardcoded circuit constants to be used when generating the prover circuits.
 
+use core::ops::Range;
+
 /// Default range to be used for the `ArithmeticStark` table.
 pub(crate) const DEFAULT_ARITHMETIC_RANGE: Range<usize> = 16..20;
 /// Default range to be used for the `BytePackingStark` table.

--- a/plonky_block_proof_gen/src/constants.rs
+++ b/plonky_block_proof_gen/src/constants.rs
@@ -1,0 +1,16 @@
+//! Hardcoded circuit constants to be used when generating the prover circuits.
+
+/// Default range to be used for the `ArithmeticStark` table.
+pub(crate) const DEFAULT_ARITHMETIC_RANGE: Range<usize> = 16..20;
+/// Default range to be used for the `BytePackingStark` table.
+pub(crate) const DEFAULT_BYTE_PACKING_RANGE: Range<usize> = 10..20;
+/// Default range to be used for the `CpuStark` table.
+pub(crate) const DEFAULT_CPU_RANGE: Range<usize> = 12..22;
+/// Default range to be used for the `KeccakStark` table.
+pub(crate) const DEFAULT_KECCAK_RANGE: Range<usize> = 14..17;
+/// Default range to be used for the `KeccakSpongeStark` table.
+pub(crate) const DEFAULT_KECCAK_SPONGE_RANGE: Range<usize> = 9..14;
+/// Default range to be used for the `LogicStark` table.
+pub(crate) const DEFAULT_LOGIC_RANGE: Range<usize> = 12..16;
+/// Default range to be used for the `MemoryStark` table.
+pub(crate) const DEFAULT_MEMORY_RANGE: Range<usize> = 17..25;

--- a/plonky_block_proof_gen/src/lib.rs
+++ b/plonky_block_proof_gen/src/lib.rs
@@ -98,6 +98,24 @@
 //! However, because the prover state can be quite heavy, the necessary verifier
 //! data to verify block proofs can be saved independently into a
 //! `VerifierState`, to allow anyone to easily verify block proofs.
+//!
+//! ```compile_fail
+//!     # use plonky_block_proof_gen::prover_state::ProverStateBuilder;
+//!     # use plonky_block_proof_gen::verifier_state::VerifierState;
+//!     let mut builder = ProverStateBuilder::default();
+//!
+//!     // Generate a `ProverState` from the builder.
+//!     let prover_state = builder.build();
+//!
+//!     // Derive a `VerifierState` from the `ProverState`.
+//!     let verifier_state: VerifierState = prover_state.into();
+//!
+//!     // The prover generates some block proof.
+//!     let block_proof = prover_state.generate_block_proof(...);
+//!     
+//!     // Have the verifier attest validity of the proof.
+//!     assert!(verifier_state.verify(block_proof.intern).is_ok());
+//! ```
 
 pub(crate) mod constants;
 pub mod proof_gen;

--- a/plonky_block_proof_gen/src/lib.rs
+++ b/plonky_block_proof_gen/src/lib.rs
@@ -95,3 +95,4 @@ pub mod proof_gen;
 pub mod proof_types;
 pub mod prover_state;
 pub mod types;
+pub mod verifier_state;

--- a/plonky_block_proof_gen/src/lib.rs
+++ b/plonky_block_proof_gen/src/lib.rs
@@ -99,6 +99,7 @@
 //! data to verify block proofs can be saved independently into a
 //! `VerifierState`, to allow anyone to easily verify block proofs.
 
+pub(crate) mod constants;
 pub mod proof_gen;
 pub mod proof_types;
 pub mod prover_state;

--- a/plonky_block_proof_gen/src/lib.rs
+++ b/plonky_block_proof_gen/src/lib.rs
@@ -90,9 +90,22 @@
 //!     curr_block_agg_proof: &GeneratedAggProof,
 //! ) -> ProofGenResult<GeneratedBlockProof> { ... }
 //! ```
+//!
+//! ## Verifying block proofs
+//!
+//! The `ProverState` can be used to verify any block proofs emitted with the
+//! same set of circuits.
+//! However, because the prover state can be quite heavy, the necessary verifier
+//! data to verify block proofs can be saved independently into a
+//! `VerifierState`, to allow anyone to easily verify block proofs.
 
 pub mod proof_gen;
 pub mod proof_types;
 pub mod prover_state;
 pub mod types;
 pub mod verifier_state;
+
+// Re-exports
+
+pub use prover_state::ProverState;
+pub use verifier_state::VerifierState;

--- a/plonky_block_proof_gen/src/prover_state.rs
+++ b/plonky_block_proof_gen/src/prover_state.rs
@@ -73,10 +73,8 @@ impl ProverStateBuilder {
     // TODO: Consider adding async version?
     /// Instantiate the prover state from the builder. Note that this is a very
     /// expensive call!
-    pub fn build(self, verbose: bool) -> ProverState {
-        if verbose {
-            info!("Initializing Plonky2 aggregation prover state (This may take a while)...");
-        }
+    pub fn build(self) -> ProverState {
+        info!("Initializing Plonky2 aggregation prover state (This may take a while)...");
 
         let state = AllRecursiveCircuits::new(
             &AllStark::default(),
@@ -92,9 +90,7 @@ impl ProverStateBuilder {
             &StarkConfig::standard_fast_config(),
         );
 
-        if verbose {
-            info!("Finished initializing Plonky2 aggregation prover state!");
-        }
+        info!("Finished initializing Plonky2 aggregation prover state!");
 
         ProverState { state }
     }

--- a/plonky_block_proof_gen/src/prover_state.rs
+++ b/plonky_block_proof_gen/src/prover_state.rs
@@ -9,6 +9,7 @@ use log::info;
 use paste::paste;
 use plonky2_evm::{all_stark::AllStark, config::StarkConfig};
 
+use crate::constants::*;
 use crate::types::AllRecursiveCircuits;
 
 /// Plonky2 proving state. Note that this is generally going to be massive in
@@ -32,17 +33,17 @@ pub struct ProverStateBuilder {
 
 impl Default for ProverStateBuilder {
     fn default() -> Self {
-        // These ranges are somewhat arbitrary, but should be enough for testing
+        // The default ranges are somewhat arbitrary, but should be enough for testing
         // purposes against most transactions.
         // Some heavy contract deployments may require bumping these ranges though.
         Self {
-            arithmetic_circuit_size: 16..20,
-            byte_packing_circuit_size: 10..20,
-            cpu_circuit_size: 12..22,
-            keccak_circuit_size: 14..17,
-            keccak_sponge_circuit_size: 9..14,
-            logic_circuit_size: 12..16,
-            memory_circuit_size: 17..25,
+            arithmetic_circuit_size: DEFAULT_ARITHMETIC_RANGE,
+            byte_packing_circuit_size: DEFAULT_BYTE_PACKING_RANGE,
+            cpu_circuit_size: DEFAULT_CPU_RANGE,
+            keccak_circuit_size: DEFAULT_KECCAK_RANGE,
+            keccak_sponge_circuit_size: DEFAULT_KECCAK_SPONGE_RANGE,
+            logic_circuit_size: DEFAULT_LOGIC_RANGE,
+            memory_circuit_size: DEFAULT_MEMORY_RANGE,
         }
     }
 }

--- a/plonky_block_proof_gen/src/prover_state.rs
+++ b/plonky_block_proof_gen/src/prover_state.rs
@@ -22,13 +22,13 @@ pub struct ProverState {
 /// Builder for the prover state.
 #[derive(Debug)]
 pub struct ProverStateBuilder {
-    arithmetic_circuit_size: Range<usize>,
-    byte_packing_circuit_size: Range<usize>,
-    cpu_circuit_size: Range<usize>,
-    keccak_circuit_size: Range<usize>,
-    keccak_sponge_circuit_size: Range<usize>,
-    logic_circuit_size: Range<usize>,
-    memory_circuit_size: Range<usize>,
+    pub(crate) arithmetic_circuit_size: Range<usize>,
+    pub(crate) byte_packing_circuit_size: Range<usize>,
+    pub(crate) cpu_circuit_size: Range<usize>,
+    pub(crate) keccak_circuit_size: Range<usize>,
+    pub(crate) keccak_sponge_circuit_size: Range<usize>,
+    pub(crate) logic_circuit_size: Range<usize>,
+    pub(crate) memory_circuit_size: Range<usize>,
 }
 
 impl Default for ProverStateBuilder {
@@ -73,10 +73,11 @@ impl ProverStateBuilder {
     // TODO: Consider adding async version?
     /// Instantiate the prover state from the builder. Note that this is a very
     /// expensive call!
-    pub fn build(self) -> ProverState {
-        info!("Initializing Plonky2 aggregation prover state (This may take a while)...");
+    pub fn build(self, verbose: bool) -> ProverState {
+        if verbose {
+            info!("Initializing Plonky2 aggregation prover state (This may take a while)...");
+        }
 
-        // ... Yeah I don't understand the mysterious ranges either :)
         let state = AllRecursiveCircuits::new(
             &AllStark::default(),
             &[
@@ -91,7 +92,9 @@ impl ProverStateBuilder {
             &StarkConfig::standard_fast_config(),
         );
 
-        info!("Finished initializing Plonky2 aggregation prover state!");
+        if verbose {
+            info!("Finished initializing Plonky2 aggregation prover state!");
+        }
 
         ProverState { state }
     }

--- a/plonky_block_proof_gen/src/types.rs
+++ b/plonky_block_proof_gen/src/types.rs
@@ -16,3 +16,11 @@ pub type AllRecursiveCircuits = plonky2_evm::fixed_recursive_verifier::AllRecurs
     PoseidonGoldilocksConfig,
     2,
 >;
+
+/// A type alias for the verifier data necessary to verify succinct block
+/// proofs.
+/// While the prover state [`AllRecursiveCircuits`] can also verify proofs, this
+/// [`VerifierData`] is much lighter, allowing anyone to verify block proofs,
+/// regardless of the underlying hardware.
+pub type VerifierData =
+    plonky2::plonk::circuit_data::VerifierCircuitData<GoldilocksField, PoseidonGoldilocksConfig, 2>;

--- a/plonky_block_proof_gen/src/verifier_state.rs
+++ b/plonky_block_proof_gen/src/verifier_state.rs
@@ -7,6 +7,7 @@ use log::info;
 use paste::paste;
 use plonky2_evm::{all_stark::AllStark, config::StarkConfig};
 
+use crate::constants::*;
 use crate::{
     prover_state::ProverState,
     types::{AllRecursiveCircuits, VerifierData},
@@ -36,17 +37,17 @@ pub struct VerifierStateBuilder {
 
 impl Default for VerifierStateBuilder {
     fn default() -> Self {
-        // These ranges are somewhat arbitrary, but should be enough for testing
+        // The default ranges are somewhat arbitrary, but should be enough for testing
         // purposes against most transactions.
         // Some heavy contract deployments may require bumping these ranges though.
         Self {
-            arithmetic_circuit_size: 16..20,
-            byte_packing_circuit_size: 10..20,
-            cpu_circuit_size: 12..22,
-            keccak_circuit_size: 14..17,
-            keccak_sponge_circuit_size: 9..14,
-            logic_circuit_size: 12..16,
-            memory_circuit_size: 17..25,
+            arithmetic_circuit_size: DEFAULT_ARITHMETIC_RANGE,
+            byte_packing_circuit_size: DEFAULT_BYTE_PACKING_RANGE,
+            cpu_circuit_size: DEFAULT_CPU_RANGE,
+            keccak_circuit_size: DEFAULT_KECCAK_RANGE,
+            keccak_sponge_circuit_size: DEFAULT_KECCAK_SPONGE_RANGE,
+            logic_circuit_size: DEFAULT_LOGIC_RANGE,
+            memory_circuit_size: DEFAULT_MEMORY_RANGE,
         }
     }
 }

--- a/plonky_block_proof_gen/src/verifier_state.rs
+++ b/plonky_block_proof_gen/src/verifier_state.rs
@@ -1,6 +1,8 @@
 //! This module defines the `VerifierState`, that contains the necessary data to
 //! handle succinct block proofs verification.
 
+use core::borrow::Borrow;
+
 use log::info;
 use plonky2::recursion::cyclic_recursion::check_cyclic_proof_verifier_data;
 
@@ -31,7 +33,7 @@ impl VerifierStateBuilder {
     /// very expensive call!
     pub fn build_verifier(self) -> VerifierState {
         info!("Initializing Plonky2 aggregation verifier state (This may take a while)...");
-        let ProverState { state } = self.build(false);
+        let ProverState { state } = self.build();
         info!("Finished initializing Plonky2 aggregation verifier state!");
 
         VerifierState {
@@ -41,10 +43,10 @@ impl VerifierStateBuilder {
 }
 
 /// Extracts the verifier state from the entire prover state.
-impl From<ProverState> for VerifierState {
-    fn from(prover_state: ProverState) -> Self {
+impl<T: Borrow<ProverState>> From<T> for VerifierState {
+    fn from(prover_state: T) -> Self {
         VerifierState {
-            state: prover_state.state.final_verifier_data(),
+            state: prover_state.borrow().state.final_verifier_data(),
         }
     }
 }

--- a/plonky_block_proof_gen/src/verifier_state.rs
+++ b/plonky_block_proof_gen/src/verifier_state.rs
@@ -1,17 +1,10 @@
 //! This module defines the `VerifierState`, that contains the necessary data to
 //! handle succinct block proofs verification.
 
-use std::ops::Range;
-
 use log::info;
-use paste::paste;
-use plonky2_evm::{all_stark::AllStark, config::StarkConfig};
 
-use crate::constants::*;
-use crate::{
-    prover_state::ProverState,
-    types::{AllRecursiveCircuits, VerifierData},
-};
+use crate::prover_state::ProverStateBuilder;
+use crate::{prover_state::ProverState, types::VerifierData};
 
 /// Plonky2 verifier state.
 ///
@@ -24,76 +17,17 @@ pub struct VerifierState {
 }
 
 /// Builder for the verifier state.
-#[derive(Debug)]
-pub struct VerifierStateBuilder {
-    arithmetic_circuit_size: Range<usize>,
-    byte_packing_circuit_size: Range<usize>,
-    cpu_circuit_size: Range<usize>,
-    keccak_circuit_size: Range<usize>,
-    keccak_sponge_circuit_size: Range<usize>,
-    logic_circuit_size: Range<usize>,
-    memory_circuit_size: Range<usize>,
-}
-
-impl Default for VerifierStateBuilder {
-    fn default() -> Self {
-        // The default ranges are somewhat arbitrary, but should be enough for testing
-        // purposes against most transactions.
-        // Some heavy contract deployments may require bumping these ranges though.
-        Self {
-            arithmetic_circuit_size: DEFAULT_ARITHMETIC_RANGE,
-            byte_packing_circuit_size: DEFAULT_BYTE_PACKING_RANGE,
-            cpu_circuit_size: DEFAULT_CPU_RANGE,
-            keccak_circuit_size: DEFAULT_KECCAK_RANGE,
-            keccak_sponge_circuit_size: DEFAULT_KECCAK_SPONGE_RANGE,
-            logic_circuit_size: DEFAULT_LOGIC_RANGE,
-            memory_circuit_size: DEFAULT_MEMORY_RANGE,
-        }
-    }
-}
-
-macro_rules! define_set_circuit_size_method {
-    ($name:ident) => {
-        paste! {
-            /// Specifies a range of degrees to be supported for this STARK
-            /// table's associated recursive circuits.
-            pub fn [<set_ $name _circuit_size>](mut self, size: Range<usize>) -> Self {
-                self.[<$name _circuit_size>] = size;
-                self
-            }
-        }
-    };
-}
+/// This is essentially the same as the [`ProverStateBuilder`], in that we need
+/// to first generate the entire prover state before extracting the verifier
+/// data.
+pub type VerifierStateBuilder = ProverStateBuilder;
 
 impl VerifierStateBuilder {
-    define_set_circuit_size_method!(arithmetic);
-    define_set_circuit_size_method!(byte_packing);
-    define_set_circuit_size_method!(cpu);
-    define_set_circuit_size_method!(keccak);
-    define_set_circuit_size_method!(keccak_sponge);
-    define_set_circuit_size_method!(logic);
-    define_set_circuit_size_method!(memory);
-
-    // TODO: Consider adding async version?
     /// Instantiate the verifier state from the builder. Note that this is a
     /// very expensive call!
-    pub fn build(self) -> VerifierState {
+    pub fn build_verifier(self) -> VerifierState {
         info!("Initializing Plonky2 aggregation verifier state (This may take a while)...");
-
-        let state = AllRecursiveCircuits::new(
-            &AllStark::default(),
-            &[
-                self.arithmetic_circuit_size,
-                self.byte_packing_circuit_size,
-                self.cpu_circuit_size,
-                self.keccak_circuit_size,
-                self.keccak_sponge_circuit_size,
-                self.logic_circuit_size,
-                self.memory_circuit_size,
-            ],
-            &StarkConfig::standard_fast_config(),
-        );
-
+        let ProverState { state } = self.build(false);
         info!("Finished initializing Plonky2 aggregation verifier state!");
 
         VerifierState {

--- a/plonky_block_proof_gen/src/verifier_state.rs
+++ b/plonky_block_proof_gen/src/verifier_state.rs
@@ -96,7 +96,9 @@ impl VerifierStateBuilder {
 
         info!("Finished initializing Plonky2 aggregation verifier state!");
 
-        VerifierState { state }
+        VerifierState {
+            state: state.final_verifier_data(),
+        }
     }
 }
 

--- a/plonky_block_proof_gen/src/verifier_state.rs
+++ b/plonky_block_proof_gen/src/verifier_state.rs
@@ -8,7 +8,7 @@ use crate::{prover_state::ProverState, types::VerifierData};
 
 /// Plonky2 verifier state.
 ///
-/// The default generation requires generating all the verifier data before
+/// The default generation requires generating all the prover data before
 /// extracting the verifier-related data, which can take a long time and require
 /// a large amount of memory.
 pub struct VerifierState {

--- a/plonky_block_proof_gen/src/verifier_state.rs
+++ b/plonky_block_proof_gen/src/verifier_state.rs
@@ -12,7 +12,8 @@ use crate::{prover_state::ProverState, types::VerifierData};
 /// extracting the verifier-related data, which can take a long time and require
 /// a large amount of memory.
 pub struct VerifierState {
-    ///
+    /// The verification circuit data associated to the block proof layer of the
+    /// plonky2 prover state.
     pub state: VerifierData,
 }
 

--- a/plonky_block_proof_gen/src/verifier_state.rs
+++ b/plonky_block_proof_gen/src/verifier_state.rs
@@ -1,0 +1,109 @@
+//! This module defines the `VerifierState`, that contains the necessary data to
+//! handle succinct block proofs verification.
+
+use std::ops::Range;
+
+use log::info;
+use paste::paste;
+use plonky2_evm::{all_stark::AllStark, config::StarkConfig};
+
+use crate::{
+    prover_state::ProverState,
+    types::{AllRecursiveCircuits, VerifierData},
+};
+
+/// Plonky2 verifier state.
+///
+/// The default generation requires generating all the verifier data before
+/// extracting the verifier-related data, which can take a long time and require
+/// a large amount of memory.
+pub struct VerifierState {
+    ///
+    pub state: VerifierData,
+}
+
+/// Builder for the verifier state.
+#[derive(Debug)]
+pub struct VerifierStateBuilder {
+    arithmetic_circuit_size: Range<usize>,
+    byte_packing_circuit_size: Range<usize>,
+    cpu_circuit_size: Range<usize>,
+    keccak_circuit_size: Range<usize>,
+    keccak_sponge_circuit_size: Range<usize>,
+    logic_circuit_size: Range<usize>,
+    memory_circuit_size: Range<usize>,
+}
+
+impl Default for VerifierStateBuilder {
+    fn default() -> Self {
+        // These ranges are somewhat arbitrary, but should be enough for testing
+        // purposes against most transactions.
+        // Some heavy contract deployments may require bumping these ranges though.
+        Self {
+            arithmetic_circuit_size: 16..20,
+            byte_packing_circuit_size: 10..20,
+            cpu_circuit_size: 12..22,
+            keccak_circuit_size: 14..17,
+            keccak_sponge_circuit_size: 9..14,
+            logic_circuit_size: 12..16,
+            memory_circuit_size: 17..25,
+        }
+    }
+}
+
+macro_rules! define_set_circuit_size_method {
+    ($name:ident) => {
+        paste! {
+            /// Specifies a range of degrees to be supported for this STARK
+            /// table's associated recursive circuits.
+            pub fn [<set_ $name _circuit_size>](mut self, size: Range<usize>) -> Self {
+                self.[<$name _circuit_size>] = size;
+                self
+            }
+        }
+    };
+}
+
+impl VerifierStateBuilder {
+    define_set_circuit_size_method!(arithmetic);
+    define_set_circuit_size_method!(byte_packing);
+    define_set_circuit_size_method!(cpu);
+    define_set_circuit_size_method!(keccak);
+    define_set_circuit_size_method!(keccak_sponge);
+    define_set_circuit_size_method!(logic);
+    define_set_circuit_size_method!(memory);
+
+    // TODO: Consider adding async version?
+    /// Instantiate the verifier state from the builder. Note that this is a
+    /// very expensive call!
+    pub fn build(self) -> VerifierState {
+        info!("Initializing Plonky2 aggregation verifier state (This may take a while)...");
+
+        let state = AllRecursiveCircuits::new(
+            &AllStark::default(),
+            &[
+                self.arithmetic_circuit_size,
+                self.byte_packing_circuit_size,
+                self.cpu_circuit_size,
+                self.keccak_circuit_size,
+                self.keccak_sponge_circuit_size,
+                self.logic_circuit_size,
+                self.memory_circuit_size,
+            ],
+            &StarkConfig::standard_fast_config(),
+        );
+
+        info!("Finished initializing Plonky2 aggregation verifier state!");
+
+        VerifierState { state }
+    }
+}
+
+/// Extracts the verifier state from the entire prover state.
+impl From<ProverState> for VerifierState {
+    fn from(prover_state: ProverState) -> Self {
+        VerifierState {
+            state: prover_state.state.final_verifier_data(),
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a `VerifierState`, similarly to how the `ProverState` is constructed to generate proofs, but to verify proofs solely.

This is aimed at simplifying https://github.com/0xPolygonZero/zero-bin/issues/4.