### PR TITLE
Fix gas update

### DIFF
--- a/protocol_decoder/src/decoding.rs
+++ b/protocol_decoder/src/decoding.rs
@@ -118,7 +118,7 @@ impl ProcessedBlockTrace {
                 // For each non-dummy txn, we increment `txn_number_after` by 1, and
                 // update `gas_used_after` accordingly.
                 extra_data.txn_number_after += U256::one();
-                extra_data.gas_used_after = txn_info.meta.gas_used.into();
+                extra_data.gas_used_after += txn_info.meta.gas_used.into();
 
                 Self::apply_deltas_to_trie_state(
                     &mut curr_block_tries,


### PR DESCRIPTION
The `gas_used_after` accumulator wasn't accumulating the current txn `gas_used`, but being reset instead, causing gas check failures post first txn of a block.