### PR TITLE
Change default constants and update `ProverStateBuilder::default()` description

### DIFF
--- a/plonky_block_proof_gen/src/constants.rs
+++ b/plonky_block_proof_gen/src/constants.rs
@@ -3,16 +3,16 @@
 use core::ops::Range;
 
 /// Default range to be used for the `ArithmeticStark` table.
-pub(crate) const DEFAULT_ARITHMETIC_RANGE: Range<usize> = 16..20;
+pub(crate) const DEFAULT_ARITHMETIC_RANGE: Range<usize> = 16..28;
 /// Default range to be used for the `BytePackingStark` table.
-pub(crate) const DEFAULT_BYTE_PACKING_RANGE: Range<usize> = 10..20;
+pub(crate) const DEFAULT_BYTE_PACKING_RANGE: Range<usize> = 9..28;
 /// Default range to be used for the `CpuStark` table.
-pub(crate) const DEFAULT_CPU_RANGE: Range<usize> = 12..22;
+pub(crate) const DEFAULT_CPU_RANGE: Range<usize> = 12..28;
 /// Default range to be used for the `KeccakStark` table.
-pub(crate) const DEFAULT_KECCAK_RANGE: Range<usize> = 14..17;
+pub(crate) const DEFAULT_KECCAK_RANGE: Range<usize> = 14..25;
 /// Default range to be used for the `KeccakSpongeStark` table.
-pub(crate) const DEFAULT_KECCAK_SPONGE_RANGE: Range<usize> = 9..14;
+pub(crate) const DEFAULT_KECCAK_SPONGE_RANGE: Range<usize> = 9..25;
 /// Default range to be used for the `LogicStark` table.
-pub(crate) const DEFAULT_LOGIC_RANGE: Range<usize> = 12..16;
+pub(crate) const DEFAULT_LOGIC_RANGE: Range<usize> = 12..28;
 /// Default range to be used for the `MemoryStark` table.
-pub(crate) const DEFAULT_MEMORY_RANGE: Range<usize> = 17..25;
+pub(crate) const DEFAULT_MEMORY_RANGE: Range<usize> = 17..30;

--- a/plonky_block_proof_gen/src/prover_state.rs
+++ b/plonky_block_proof_gen/src/prover_state.rs
@@ -32,10 +32,14 @@ pub struct ProverStateBuilder {
 }
 
 impl Default for ProverStateBuilder {
+    /// Generates a new builder from a set of default ranges.
+    /// These ranges should be sufficient to prove any transaction,
+    /// but will require a significant amount of RAM (around 30GB).
+    ///
+    /// Specifying shorter ranges will allow for a lower memory
+    /// consumption, with the drawback of possibly not being sufficient
+    /// for some transactions.
     fn default() -> Self {
-        // The default ranges are somewhat arbitrary, but should be enough for testing
-        // purposes against most transactions.
-        // Some heavy contract deployments may require bumping these ranges though.
         Self {
             arithmetic_circuit_size: DEFAULT_ARITHMETIC_RANGE,
             byte_packing_circuit_size: DEFAULT_BYTE_PACKING_RANGE,


### PR DESCRIPTION
cf Jira ticket

Default parameters are now sufficient for any transaction (as we should expect default values to be), and added explanation about the tradeoff memory consumption / provable transactions.